### PR TITLE
Add brand strategy document capturing positioning decisions

### DIFF
--- a/meta/brand-audit-2026-02-13.md
+++ b/meta/brand-audit-2026-02-13.md
@@ -1,0 +1,24 @@
+# Brand Audit: FlowerShow Today
+
+Current positioning: "Markdown to website in seconds" -- a tool-centric, feature-forward pitch. The landing page is essentially a feature list with a demo video. It tells you what FlowerShow does, but not why it matters or what world it's building toward.
+
+## What's working
+
+- The name is memorable and has a nice metaphor (showcasing your digital garden)
+- The free tier + simple pricing is clean
+- The CLI page ("Turn local files into websites") is actually the strongest copy on the whole site -- it has energy, a clear pain point, and speaks to a workflow
+- "Own your content" is a genuinely differentiating value
+
+## What's not working
+
+- The identity is fractured across three products (Cloud, CLI, Self-hosted) without a unifying story
+- "Markdown to website" is a how, not a why -- it limits the audience and sounds like a dev tool
+- "For geeks who value their time" actively narrows the market and has no emotional resonance
+- The landing page reads like a Tailwind UI template filled in with feature bullets -- competent but forgettable
+- The About page anchors in 2022-era digital garden culture (Obsidian, Roam) which is already aging
+- There's no narrative arc -- no tension, no transformation, no aspiration
+- The "bigger picture" (collective sensemaking) is buried on a page nobody reads, and it's actually the most compelling part of the whole brand
+
+## The core tension
+
+FlowerShow is currently about markdown but wants to be about publishing in the AI age. That's not a small pivot -- it's a category shift from "markdown converter" to "content publishing infrastructure."

--- a/meta/brand-strategy.md
+++ b/meta/brand-strategy.md
@@ -1,0 +1,119 @@
+# Flowershow Brand Strategy
+
+## Decision Summary
+
+Lead with the **practical promise** (speed, simplicity, time saved). Let the **bigger vision** (publishing rebuilt for the AI age, collective sensemaking) emerge as narrative depth underneath.
+
+## The Two Layers
+
+### Layer 1: Headline / Hero (A+C)
+
+**The practical promise.** This is what hits you in the first 3 seconds.
+
+> **Content to URL. Instantly.**
+>
+> Stop wrestling with build pipelines, CMS configs, and deploy scripts. Drop your files, get a live website. Docs, blogs, landing pages, anything -- published in seconds, not hours.
+
+**Why this works:**
+- Immediate clarity -- you know exactly what Flowershow does
+- Sells the *experience*, not the technology
+- Speaks to the pain everyone has felt (too many steps, too much config)
+- "For geeks who value their time" energy, without being exclusionary
+
+**Key messages at this layer:**
+- Speed: seconds, not hours
+- Simplicity: no repos, no builds, no pipelines
+- Breadth: docs, blogs, landing pages, knowledge bases, anything markdown
+
+### Layer 2: Narrative / Scroll (D)
+
+**The manifesto.** This is what you discover as you spend 30 seconds to 3 minutes on the site.
+
+> **Publishing rebuilt for the AI age.**
+>
+> Content moves faster than ever. Your publishing tools should too. FlowerShow turns any content into a live website in seconds -- no repos, no builds, no waiting.
+
+**Why this works:**
+- Gives Flowershow a *reason to exist* beyond the feature set
+- "The world changed, we noticed, here's what we built"
+- Provides years of strategic runway -- every new feature, format, and AI integration fits under this umbrella
+- Connects to the deeper story without requiring the reader to buy in immediately
+
+**Key messages at this layer:**
+- The world of content creation has changed (AI, speed, volume)
+- Publishing infrastructure hasn't kept up
+- FlowerShow is what publishing looks like when you start from scratch today
+
+### Layer 3: Vision / About (The Bigger Picture)
+
+**The deeper why.** This lives on the About page and in long-form content. For the audience that wants to understand the philosophy.
+
+- Tools matter. The ability to publish and share -- fast, easily, reliably -- matters.
+- Better publishing tools are part of better collective sensemaking
+- Markdown as durable, composable foundation (the "markdown revolution")
+- Open ecosystem over walled gardens
+- This connects to the existing About page section "The Bigger Picture"
+
+## Three Layers of Attention
+
+| Time | Layer | What they get |
+|------|-------|---------------|
+| 3 seconds | Hero headline | The value prop: content to URL, instantly |
+| 30 seconds | Scroll narrative | The "why now" story: publishing rebuilt for the AI age |
+| 3 minutes | About / deeper content | The vision: collective sensemaking, tools that help people think together |
+
+## Positioning Pillars
+
+### A. Speed & Immediacy
+"Seconds, not hours." The core experience promise. Everything about FlowerShow should feel instant.
+
+### B. Simplicity & Elegance
+No configuration, no build steps, no maintenance. Beautiful by default. Complexity is our problem, not the user's.
+
+### C. Time Saved (Cost of Switching)
+"Yes, you *could* code your own site. But is that really the best use of your time?" Respect the user's capability while pointing out the opportunity cost.
+
+### D. Future of Publishing (Strategic Narrative)
+Publishing infrastructure for the AI age. Content moves faster than ever. We're what publishing looks like when you design for today's reality, not yesterday's.
+
+## How These Pillars Map to the Site
+
+- **Homepage hero**: A + C (the practical promise)
+- **Homepage scroll / features**: A + B (speed + elegance in action)
+- **Homepage narrative section**: D (the "why now" story)
+- **About page**: D + the bigger picture (collective sensemaking)
+- **Blog / content marketing**: Mix of all, with D as recurring thread
+- **CLI / Publish page**: A + C (speed for power users and AI agents)
+
+## Tagline Candidates
+
+**Primary (hero):**
+- Content to URL. Instantly.
+- Markdown to website in seconds. *(current -- still strong)*
+
+**Secondary (narrative):**
+- Publishing rebuilt for the AI age.
+- The publishing layer for everything.
+
+**Tertiary (about/manifesto):**
+- Tools for collective sensemaking.
+- Publish. Share. Think together.
+
+## What This Means for the Homepage
+
+The current homepage structure is already close. The main evolution:
+
+1. **Hero**: Keep the practical headline. Consider tightening to "Content to URL. Instantly." or keep "Markdown to website in seconds" -- both work.
+2. **After features grid**: Add a narrative section that introduces the "why now" / "publishing rebuilt" story. This doesn't exist yet and would add the D layer.
+3. **Community sites**: Keep as social proof (already strong).
+4. **Final CTA**: Keep as is.
+
+## Audiences and How They Experience the Layers
+
+**The pragmatist** (most visitors): Gets Layer 1, maybe Layer 2. Signs up because it saves them time. Never reads the About page. That's fine.
+
+**The curious builder**: Gets Layer 1, reads Layer 2, thinks "these people get it." Becomes an advocate. Might self-host, might build on top of FlowerShow.
+
+**The aligned thinker**: Gets all three layers. Sees FlowerShow as part of a bigger movement. Shares the About page. Writes about it. Becomes a long-term community member.
+
+All three audiences are served. Nobody is asked to buy into the vision before they've seen the value.

--- a/meta/brand-strategy.md
+++ b/meta/brand-strategy.md
@@ -117,3 +117,102 @@ The current homepage structure is already close. The main evolution:
 **The aligned thinker**: Gets all three layers. Sees FlowerShow as part of a bigger movement. Shares the About page. Writes about it. Becomes a long-term community member.
 
 All three audiences are served. Nobody is asked to buy into the vision before they've seen the value.
+
+---
+
+## Appendix A: Initial Analysis
+
+### Starting Point: What Does Flowershow Actually Do?
+
+Flowershow takes markdown content and turns it into a live, hosted website. No repos to configure, no build pipelines, no deploy scripts. Connect content (via GitHub or CLI), get a URL. It supports docs, blogs, landing pages, knowledge bases, digital gardens -- anything that starts as markdown.
+
+The existing positioning ("Markdown to website in seconds / For geeks who value their time") is functional and honest, but doesn't differentiate strongly or tell a story about *why Flowershow exists*. It describes the what without the why.
+
+### The Core Question: What Story Do We Tell?
+
+Four candidate positioning pillars emerged from analyzing the product, the market, and the existing brand materials (about page, homepage, blog):
+
+**A. Speed & Immediacy**
+- The experience of going from content to live URL in seconds
+- "Instant deployment" as the headline promise
+- Strongest when demonstrated (demo video, CLI in action)
+- Risk: speed alone is a feature, not a brand. Others can claim speed too.
+
+**B. Simplicity & Elegance**
+- Beautiful by default, no configuration required
+- "It just works and it looks good"
+- Supported by the existing themes, layout, design quality
+- Risk: subjective, hard to prove in a headline. Better shown than told.
+
+**C. Time Saved / Cost of Switching**
+- "You could build this yourself. Should you?"
+- Respects the audience's technical capability while reframing the decision
+- The asterisk footnote on the current homepage already gestures at this
+- Risk: negative framing (what you're *not* doing) rather than positive (what you *are* doing). Works better as supporting argument than lead.
+
+**D. Future of Publishing / Strategic Narrative**
+- "Publishing rebuilt for the AI age"
+- Content creation has changed fundamentally (AI, speed, volume). Publishing infrastructure hasn't kept up. Flowershow is what you'd build if you started from scratch today.
+- Connects to the deeper story: collective sensemaking, tools that matter, open ecosystem
+- Risk: could feel like too much for a product at this stage. Vision statements need to be earned.
+
+### Initial Assessment
+
+- **A and C naturally pair together** as the practical promise: speed + "is this really the best use of your time?" = a complete value proposition for the pragmatic user
+- **B supports A** but doesn't lead well on its own (elegance is shown, not claimed)
+- **D is the most differentiated and durable** but also the riskiest to lead with -- it asks the audience to buy into a worldview before they've seen the product
+- The existing about page already has strong D-layer content ("The Bigger Picture" section on collective sensemaking) that is underutilized
+
+This set up the key strategic tension: **practical lead (A+C) vs visionary lead (D)?**
+
+---
+
+## Appendix B: Level 3 Questions and Discussion
+
+### Q1: Should we foreground A+C (practical promise) or D (visionary narrative)?
+
+**The tension:** A+C is safer, more immediately legible, and sells the experience. D is more differentiated, gives the brand more runway, and tells a bigger story. But D could feel presumptuous -- "we're building the publishing infrastructure for the future" is a big claim for what is (today) a markdown-to-website tool.
+
+**Discussion:** The hesitation was real: "I'm just not sure if that's a bit much vs combining A and C together as speed, simplicity, and save time." The concern wasn't that D was wrong -- it was that leading with D might over-promise or feel grandiose relative to where the product is today.
+
+**Resolution:** We tested this concretely with two headline versions:
+
+> *Version 1 (A+C lead):* "Content to URL. Instantly. Stop wrestling with build pipelines, CMS configs, and deploy scripts."
+>
+> *Version 2 (D lead):* "Publishing rebuilt for the AI age. Content moves faster than ever. Your publishing tools should too."
+
+The verdict was clear: **"Definitely headline 1 is better for us."** Version 2 was identified as "more like a manifesto or vision statement" -- valuable, but not as the first thing someone sees.
+
+**Decision: A+C leads. D sits underneath as narrative depth.**
+
+### Q2: Where does D live if it doesn't lead?
+
+**The tension:** If D isn't the headline, does it disappear? Is it relegated to the About page where nobody reads it?
+
+**Discussion:** The answer was structural: give D its own section on the homepage, *after* the features grid. The user has already been sold on what Flowershow does (Layer 1). Now they're ready for *why it exists* (Layer 2). This is the scroll narrative -- you discover it as you spend more time on the page.
+
+**Decision: Add a "why now" / narrative section to the homepage between features and community sites.** This is the main structural change needed on the site.
+
+### Q3: How does the collective sensemaking story connect?
+
+**The tension:** The about page has a rich section on collective sensemaking, the markdown revolution, and why publishing tools matter for how we think together. But it feels disconnected from the homepage's practical tone. How do you bridge "content to URL in seconds" to "tools for collective sensemaking" without whiplash?
+
+**Discussion:** The insight was that D ("publishing rebuilt for the AI age") serves as the *bridge*. It's concrete enough to follow naturally from the practical promise, but philosophical enough to point toward the bigger story. The connection: tools matter. The ability to publish and share -- fast, easily, reliably -- matters. Not just for convenience, but because better publishing tools are part of better collective sensemaking.
+
+The user put it directly: "The second is more like a manifesto or vision statement -- which even relates to collective sensemaking as bigger story. Tools matter and ability to publish and share fast and easily and reliably matters."
+
+**Decision: Three-layer architecture.** Practical promise (hero) -> publishing rebuilt narrative (scroll) -> collective sensemaking vision (about/long-form). Each layer earns the right to the next. Nobody is asked to buy the philosophy before they've seen the value.
+
+### Q4: Is "Markdown to website in seconds" still the right headline?
+
+**The tension:** The current headline is good -- accurate, clear, specific. But "Content to URL. Instantly." is punchier and slightly broader (doesn't limit to markdown). Which to use?
+
+**Discussion:** Both were acknowledged as strong. "Markdown to website in seconds" has the advantage of specificity -- it immediately signals the audience (people who write markdown). "Content to URL. Instantly." is more universal but loses that signal.
+
+**Decision: Left open for testing.** Both are viable. The strategy works with either headline. The key insight is that whichever headline is chosen, it should be the practical promise (A+C), not the visionary narrative (D).
+
+### Q5: Does B (Simplicity & Elegance) need its own positioning, or is it implicit?
+
+**Discussion:** B is best demonstrated, not claimed. The product screenshots, the demo video, the community showcase sites -- these all communicate elegance without needing to say "we're elegant." B shows up in the features section ("beautiful by default," "hosted for you," "customizable themes") and in the visual design of the site itself.
+
+**Decision: B is a supporting pillar, not a lead message.** It's present everywhere in the *experience* of the site without needing its own headline or narrative section.

--- a/meta/brand-strategy.md
+++ b/meta/brand-strategy.md
@@ -122,6 +122,51 @@ All three audiences are served. Nobody is asked to buy into the vision before th
 
 ## Appendix A: Initial Analysis
 
+### Current State of the Brand
+
+**Homepage (README.md):**
+- Headline: "Markdown to website in seconds"
+- Subtitle: "Fastest way to turn markdown into a website -- from blogs to docs, landing pages to knowledgebases. For geeks who value their time."
+- CTA: "Start publishing (free forever)"
+- Demo video as hero asset
+- Six feature bullets: instant deployment, folder-based publishing, markdown-based, hosted for you, own your content, custom domains and themes
+- Feature showcase sections: syntax support, comments, layout, themes, hero sections
+- Community sites gallery (12 examples)
+- Newsletter signup
+- Final CTA: "Start using Flowershow today"
+
+**About page:**
+- Origin story: started as internal tooling for markdown-driven sites, evolved through Obsidian adoption
+- Mission: make publishing markdown "as easy as publishing a Facebook post"
+- "The Bigger Picture" section with a developed argument: we need better collective sensemaking -> one part of that is tooling -> markdown revolution -> publishing is one important initial area
+- This is the strongest existing brand writing, but it lives on a page most visitors will never see
+
+**Existing taglines (from meta/plan.md):**
+- "Author in Obsidian, Publish in Flowershow"
+- "Present your ideas, beautifully"
+- "Share your digital garden"
+- "Turn your digital garden / second brain / obsidian vault into a beautiful (and customizable) website in seconds"
+
+**Sub-pages (blogs.md, data-stories.md, publish.md):**
+- Each has its own positioning adapted to the use case
+- CLI page ("publish.md") notably mentions AI agents as a use case -- an early signal of the D narrative
+- Blogs page leads with "The best way to create markdown-based blogs"
+- Data stories page leads with "Tell data-rich stories with Markdown"
+
+**What's working:**
+- The homepage is clear and functional. You land on it and know what Flowershow does.
+- The demo video is a strong proof point.
+- The community showcases provide genuine social proof.
+- The about page has real philosophical depth (collective sensemaking argument).
+- The product genuinely delivers on the speed promise.
+
+**What's missing:**
+- No narrative layer between "here's what it does" and "here's our philosophy of collective sensemaking." The jump from homepage to about page is from pure utility to deep philosophy with nothing in between.
+- No "why now" story. The homepage doesn't explain why Flowershow exists *at this moment* -- what changed in the world that makes this needed.
+- The existing taglines are Obsidian-centric ("digital garden," "vault"). The product has outgrown this framing -- it serves anyone with markdown content.
+- The strongest brand thinking (the about page) is disconnected from the front door (the homepage).
+- No differentiation story. Speed and simplicity are claimed but not contextualized. *Why* is publishing still hard? *Why* does it matter that it's easy?
+
 ### Starting Point: What Does Flowershow Actually Do?
 
 Flowershow takes markdown content and turns it into a live, hosted website. No repos to configure, no build pipelines, no deploy scripts. Connect content (via GitHub or CLI), get a URL. It supports docs, blogs, landing pages, knowledge bases, digital gardens -- anything that starts as markdown.


### PR DESCRIPTION
Practical promise (speed, simplicity) leads as headline; "publishing
rebuilt for the AI age" and collective sensemaking narrative sit
underneath as depth layers. Documents three-layer attention model,
positioning pillars, and how they map to site structure.

https://claude.ai/code/session_01JdG3o74UhVeAAFFyM8BBPt